### PR TITLE
feat: always fetch the latest `taoRelease` before executing it

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -17,6 +17,10 @@ echo "Prepare NPM ..."
 
 npm config set //registry.npmjs.org/:_authToken=${NPM_TOKEN}
 
+echo "Upgrade taoRelease ..."
+
+npm update -g @oat-sa/tao-extension-release
+
 echo "Prepare composer file ..."
 
 COMPOSER_GENERATION_OUTPUT=$(php generateComposerFile.php)


### PR DESCRIPTION
Since the [action-time image](https://hub.docker.com/layers/goodnickoff/taorelease/0.0.14/images/sha256-c58482b61b60f0d7829217ef8983defe8542ab1ee7b2f0ccf86c3d7d2db18ae9?context=explore) is pre-build, it has a fixed version of [taoRelease](https://github.com/oat-sa/tao-extension-release).

This PR's intention is to fetch the latest version on each action execution, so that it's not needed to rebuild the whole image each time taoRelease gets updated.