### PR TITLE
fix: allow plugins from oat to be executed

### DIFF
--- a/generateComposerFile.php
+++ b/generateComposerFile.php
@@ -8,6 +8,11 @@ $composerArray["repositories"][] = [
     "type" => "vcs",
     "url" => "https://github.com/".$composerArray["name"].".git"
 ];
+
+$composerArray['config'] = $composerArray['config'] ?? [];
+$composerArray['config']['allow-plugins'] = $composerArray['config']['allow-plugins'] ?? [];
+$composerArray['config']['allow-plugins']['oat-sa/*'] = true;
+
 unset($composerArray['name']);
 file_put_contents('./composer-release.json', json_encode($composerArray, JSON_PRETTY_PRINT | JSON_UNESCAPED_SLASHES));
 


### PR DESCRIPTION
Allow tao plugins to be executed 

Necessary for this case: 

```
Error: oat-sa/oatbox-extension-installer contains a Composer plugin which is blocked by your allow-plugins config. You may add it to the list if you consider it safe.
You can run "composer config --no-plugins allow-plugins.oat-sa/oatbox-extension-installer [true|false]" to enable it (true) or disable it explicitly and suppress this exception (false)
See https://getcomposer.org/allow-plugins
In PluginManager.php line 738:
```

https://github.com/oat-sa/extension-tao-advanced-search/actions/runs/3143105952/jobs/5107465601

