### PR TITLE
feature/ADF-1419/Update the image to Node 18

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM taotesting/tao-release:latest
+FROM taotesting/tao-release:1.1
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM taotesting/tao-release:1.1
+FROM taotesting/tao-release:latest
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh

--- a/README.md
+++ b/README.md
@@ -9,9 +9,11 @@ This action used to automatically release tao extension
 ## Outputs
 
 ### `release_result`
+
 release result message: success|skip|failure
 
 ## Example usage
+
 ```
 name: Relese Tao extension
 on:
@@ -38,8 +40,9 @@ jobs:
 ## Publishing
 
 Actions are released as tags:
-- one tag that reflects the exact version
-- a major version tag that points to the last tag of that version
+
+-   one tag that reflects the exact version
+-   a major version tag that points to the last tag of that version
 
 For example, when releasing the version `v1.2.3`, ensure the tag `v1` points to that version as well.
 Check the code example bellow:
@@ -56,7 +59,7 @@ git push origin v1
 
 ## Releasing tao-release Docker image
 
-1) Login as a user that has access and execute:
+1. Login as a user that has access and execute:
 
 ```shell
 cd docker
@@ -69,6 +72,36 @@ docker tag taotesting/tao-release:1.0 taotesting/tao-release:latest
 docker push taotesting/tao-release:latest
 ```
 
-2) Check if the image is there
+2. Check if the image is there
 
 Access [docker hub](https://hub.docker.com/repository/docker/taotesting/tao-release).
+
+## Creating and publishing a multi arch image
+
+For Apple Silicon owners, and other ARM powered machine, here is how to build an publish the images.
+
+**Note:** the image build will come together with the publication. This is needed to push directly to a repository if you want Docker Desktop to automatically manage the manifest list for you.
+
+First you need to prepare the engine:
+
+-   enable the `Experimental Features` in Docker (from the config options in the desktop application)
+-   start the engine: `docker buildx create --use`
+
+Build and publish a multi arch image:
+
+```
+docker buildx build --platform linux/amd64,linux/arm64 --push -t taotesting/tao-release:1.1 -f Dockerfile-tao-release .
+```
+
+**Note:** you will need to use the proper tag as it would be better to use a different version, like `1.2`, `1.3`, etc.
+
+Tag the new image as the latest:
+
+```
+docker buildx imagetools create -t taotesting/tao-release:latest taotesting/tao-release:1.1
+```
+
+Reference:
+
+-   https://blog.jaimyn.dev/how-to-build-multi-architecture-docker-images-on-an-m1-mac/
+-   https://stackoverflow.com/questions/74066597/how-to-tag-multi-architecture-docker-image-and-push-the-newly-tagged-image

--- a/docker/Dockerfile-tao-release
+++ b/docker/Dockerfile-tao-release
@@ -1,7 +1,7 @@
 #
 # Dockerfile used to generate https://hub.docker.com/repository/docker/taotesting/tao-release
 #
-FROM ubuntu:18.04
+FROM ubuntu:20.04
 
 ENV DEBIAN_FRONTEND=noninteractive
 ENV COMPOSER_ALLOW_SUPERUSER=1
@@ -12,7 +12,7 @@ RUN apt-get install -y software-properties-common
 RUN apt-add-repository ppa:ondrej/php
 RUN apt-get update
 RUN apt-get install -y php7.4 php7.4-pdo php7.4-mbstring php7.4-dom php7.4-zip php7.4-gd php7.4-curl npm git jq python3 g++ make curl
-RUN curl -sL https://deb.nodesource.com/setup_12.x | bash
+RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get install -y nodejs
 RUN npm i -g @oat-sa/tao-extension-release
 RUN curl -sS https://getcomposer.org/installer -o composer-setup.php


### PR DESCRIPTION
### Related to: https://oat-sa.atlassian.net/browse/ADF-1419

### Summary

Update the base image to use Ubuntu 20.04 and Node.js 18

### Details

This is required for migrating our codebase to use Node 18

### How to test

Build the image locally:
```
cd docker
docker build -t taotesting/tao-release:latest -f Dockerfile-tao-release .
```

The build should complete successfully

```
[+] Building 111.1s (19/19) FINISHED
 => [internal] load build definition from Dockerfile-tao-release                                                                                                                                                                                                         0.0s
 => => transferring dockerfile: 995B                                                                                                                                                                                                                                     0.0s
 => [internal] load .dockerignore                                                                                                                                                                                                                                        0.0s
 => => transferring context: 2B                                                                                                                                                                                                                                          0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                                                                                                          1.9s
 => [auth] library/ubuntu:pull token for registry-1.docker.io                                                                                                                                                                                                            0.0s
 => CACHED [ 1/14] FROM docker.io/library/ubuntu:20.04@sha256:db8bf6f4fb351aa7a26e27ba2686cf35a6a409f65603e59d4c203e58387dc6b3                                                                                                                                           0.0s
 => [ 2/14] RUN apt-get update                                                                                                                                                                                                                                           2.8s
 => [ 3/14] RUN apt-get install -y software-properties-common                                                                                                                                                                                                           19.6s
 => [ 4/14] RUN apt-add-repository ppa:ondrej/php                                                                                                                                                                                                                        2.1s
 => [ 5/14] RUN apt-get update                                                                                                                                                                                                                                           1.4s
 => [ 6/14] RUN apt-get install -y php7.4 php7.4-pdo php7.4-mbstring php7.4-dom php7.4-zip php7.4-gd php7.4-curl npm git jq python3 g++ make curl                                                                                                                       55.9s
 => [ 7/14] RUN curl -sL https://deb.nodesource.com/setup_18.x | bash                                                                                                                                                                                                    3.6s
 => [ 8/14] RUN apt-get install -y nodejs                                                                                                                                                                                                                                5.0s
 => [ 9/14] RUN npm i -g @oat-sa/tao-extension-release                                                                                                                                                                                                                  14.7s
 => [10/14] RUN curl -sS https://getcomposer.org/installer -o composer-setup.php                                                                                                                                                                                         0.5s
 => [11/14] RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer                                                                                                                                                                                  1.2s
 => [12/14] RUN composer self-update                                                                                                                                                                                                                                     0.5s
 => [13/14] RUN mkdir -p /run/systemd && echo 'docker' > /run/systemd/container                                                                                                                                                                                          0.2s
 => [14/14] RUN ln -snf /usr/share/zoneinfo/Europe/Luxembourg /etc/localtime     && echo Europe/Luxembourg > /etc/timezone                                                                                                                                               0.3s
 => exporting to image                                                                                                                                                                                                                                                   1.3s
 => => exporting layers                                                                                                                                                                                                                                                  1.3s
 => => writing image sha256:0e25bcf3306a5a496111fb432c9b1ae9e010bd589b70a19bf212b4ce36862d7d                                                                                                                                                                             0.0s
 => => naming to docker.io/taotesting/tao-release:latest
```