### PR TITLE
feat: update image php version to 8.3

### DIFF
--- a/docker/Dockerfile-tao-release
+++ b/docker/Dockerfile-tao-release
@@ -11,7 +11,7 @@ RUN apt-get update
 RUN apt-get install -y software-properties-common
 RUN apt-add-repository ppa:ondrej/php
 RUN apt-get update
-RUN apt-get install -y php7.4 php7.4-pdo php7.4-mbstring php7.4-dom php7.4-zip php7.4-gd php7.4-curl npm git jq python3 g++ make curl
+RUN apt-get install -y php8.3 php8.3-pdo php8.3-mbstring php8.3-dom php8.3-zip php8.3-gd php8.3-curl npm git jq python3 g++ make curl
 RUN curl -sL https://deb.nodesource.com/setup_18.x | bash
 RUN apt-get install -y nodejs
 RUN npm i -g @oat-sa/tao-extension-release


### PR DESCRIPTION
Related to https://oat-sa.atlassian.net/browse/REL-1901

### Summary

Update the base image to use php 8.3

### Details

This is required to build our extensions, since generis has dependency on packages that require php8

### How to test

Build the image locally:
```
cd docker
docker build -t taotesting/tao-release:latest -f Dockerfile-tao-release .
```

The build should complete successfully

```
$ docker build -t taotesting/tao-release:latest -f Dockerfile-tao-release .
[+] Building 185.8s (18/18) FINISHED                                                                                                                                                         docker:default
 => [internal] load build definition from Dockerfile-tao-release                                                                                                                                       0.1s
 => => transferring dockerfile: 995B                                                                                                                                                                   0.0s
 => [internal] load metadata for docker.io/library/ubuntu:20.04                                                                                                                                        1.8s
 => [internal] load .dockerignore                                                                                                                                                                      0.0s
 => => transferring context: 2B                                                                                                                                                                        0.0s
 => [ 1/14] FROM docker.io/library/ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b                                                                                1.4s
 => => resolve docker.io/library/ubuntu:20.04@sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b                                                                                  0.0s
 => => sha256:d9802f032d6798e2086607424bfe88cb8ec1d6f116e11cd99592dcaf261e9cd2 27.51MB / 27.51MB                                                                                                       0.7s
 => => sha256:8e5c4f0285ecbb4ead070431d29b576a530d3166df73ec44affc1cd27555141b 6.69kB / 6.69kB                                                                                                         0.0s
 => => sha256:e5a6aeef391a8a9bdaee3de6b28f393837c479d8217324a2340b64e45a81e0ef 424B / 424B                                                                                                             0.0s
 => => sha256:6013ae1a63c2ee58a8949f03c6366a3ef6a2f386a7db27d86de2de965e9f450b 2.30kB / 2.30kB                                                                                                         0.0s
 => => extracting sha256:d9802f032d6798e2086607424bfe88cb8ec1d6f116e11cd99592dcaf261e9cd2                                                                                                              0.5s
 => [ 2/14] RUN apt-get update                                                                                                                                                                         3.0s
 => [ 3/14] RUN apt-get install -y software-properties-common                                                                                                                                         43.1s 
 => [ 4/14] RUN apt-add-repository ppa:ondrej/php                                                                                                                                                      2.5s 
 => [ 5/14] RUN apt-get update                                                                                                                                                                         1.8s 
 => [ 6/14] RUN apt-get install -y php8.3 php8.3-pdo php8.3-mbstring php8.3-dom php8.3-zip php8.3-gd php8.3-curl npm git jq python3 g++ make curl                                                    107.4s 
 => [ 7/14] RUN curl -sL https://deb.nodesource.com/setup_18.x | bash                                                                                                                                  5.0s 
 => [ 8/14] RUN apt-get install -y nodejs                                                                                                                                                              5.3s 
 => [ 9/14] RUN npm i -g @oat-sa/tao-extension-release                                                                                                                                                 9.8s 
 => [10/14] RUN curl -sS https://getcomposer.org/installer -o composer-setup.php                                                                                                                       0.5s 
 => [11/14] RUN php composer-setup.php --install-dir=/usr/local/bin --filename=composer                                                                                                                1.0s 
 => [12/14] RUN composer self-update                                                                                                                                                                   0.4s 
 => [13/14] RUN mkdir -p /run/systemd && echo 'docker' > /run/systemd/container                                                                                                                        0.2s 
 => [14/14] RUN ln -snf /usr/share/zoneinfo/Europe/Luxembourg /etc/localtime     && echo Europe/Luxembourg > /etc/timezone                                                                             0.2s 
 => exporting to image                                                                                                                                                                                 2.3s 
 => => exporting layers                                                                                                                                                                                2.2s
 => => writing image sha256:1b4bfbf0a98bee3d56f98f852c2ec104ba25f5cc0653659ccd6d3fc57bccfa86                                                                                                           0.0s
 => => naming to docker.io/taotesting/tao-release:latest
 ```