### PR TITLE
chore: revert from latest to older tags to allow using php74

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Container image that runs your code
-FROM taotesting/tao-release:latest
+FROM taotesting/tao-release:1.1
 
 # Copies your code file from your action repository to the filesystem path `/` of the container
 COPY entrypoint.sh /entrypoint.sh


### PR DESCRIPTION
Just a revert from latest to v1.1 of docker image to allow using php74 for older extensions